### PR TITLE
Set up the documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Pages
         id: pages
@@ -45,7 +45,7 @@ jobs:
           popd
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: docs/build/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: docs
+
+on:
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies and build python module
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install --verbose .[docs]
+
+      - name: Build docs
+        run: |
+          pushd docs
+          sphinx-apidoc -M -o source/api ../src/nird/ --force
+          make html
+          popd
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/build/html
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cover/
 
 # Sphinx documentation
 docs/build/
+docs/source/api/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -61,3 +61,31 @@ To install new packages, add them to `environment.yaml` then run:
 To add new pre-commit hooks, configure them in `.pre-commit-config.yaml` then run:
 
     pre-commit run --all-files
+
+### Building documentation
+
+The documentation site is developed in the `./docs` directory using [Sphinx](https://www.sphinx-doc.org/en/master/usage/index.html).
+
+To build the docs:
+
+```bash
+cd docs
+# generate the API docs (this pulls information from the code and docstrings)
+sphinx-apidoc -M -o source/api ../src/nird/ --force
+# build the documentation site
+make html
+```
+
+To preview the site:
+
+```
+cd build/html
+python -m http.server
+```
+
+Then open a browser at the address shown (e.g. `http://0.0.0.0:8000`).
+
+## Acknowledgments
+
+This project was developed as part of a UKRI-funded research grant, reference ST/Y003780/1,
+supported by STFC and DAFNI, within the "Building a Secure and Resilient World" theme.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/_static/theme_tweaks.css
+++ b/docs/source/_static/theme_tweaks.css
@@ -1,0 +1,21 @@
+/* sticky sidebar at non-mobile screen size */
+@media screen and (min-width: 876px) {
+    div.sphinxsidebar {
+        position: fixed;
+        float: none;
+        margin-left: 0;
+        top: 2em;
+        bottom: 0;
+        overflow: auto;
+    }
+}
+div.document,
+div.footer {
+    width: auto;
+    max-width: 940px;
+}
+
+/* no border on image links */
+a.image-reference:hover {
+    border-bottom: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+
+# -- Project information --
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+project = "nird"
+copyright = "2023, nird contributors"
+author = "nird contributors"
+
+# The short X.Y version
+version = ""
+# The full version, including alpha/beta/rc tags
+release = ""
+
+try:
+    from nird import __version__
+
+    version = __version__
+except ImportError:
+    pass
+else:
+    release = version
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+
+# Extra styles, found in _static
+def setup(app):
+    app.add_css_file("theme_tweaks.css")
+
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.viewcode",
+    "m2r2",
+]
+templates_path = ["_templates"]
+exclude_patterns = []
+
+# The suffix(es) of source filenames.
+source_suffix = [".rst", ".md"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+
+html_title = project
+html_short_title = project
+html_static_path = ["_static"]
+html_theme_options = {"show_powered_by": False}

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,0 +1,4 @@
+# Getting Started
+
+For now, the best place to start is with the
+[source code itself](https://github.com/nismod/DAFNI-NIRD).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,45 @@
+===============================================
+National Infrastructure Resilience Demonstrator
+===============================================
+
+``nird`` is a Python package to help with analysis of the resilience of national
+infrastructure networks.
+
+.. image:: https://img.shields.io/badge/github-nird-brightgreen.svg
+   :target: https://github.com/nismod/DAFNI-NIRD/
+   :alt: nird on github
+
+.. mdinclude:: ../../README.md
+   :start-line: 4
+   :end-line: 59
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   Getting Started <getting_started>
+
+.. toctree::
+   :maxdepth: 3
+
+   Reference <api/modules>
+
+.. toctree::
+   :maxdepth: 1
+
+   License <license>
+
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,0 +1,7 @@
+.. _license:
+
+=======
+License
+=======
+
+.. literalinclude:: ../../LICENSE

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.12
   - black
+  - make
   - m2r2
   - mypy
   - pre-commit

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,11 +5,13 @@ channels:
 dependencies:
   - python=3.12
   - black
+  - m2r2
+  - mypy
   - pre-commit
   - pytest
   - pytest-cov
+  - ruff
+  - sphinx
   - pip
   - pip:
-      - ruff
-      - mypy
       - --editable .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ testpaths = ["tests"]
 src = ["src"]
 
 [tool.mypy]
-exclude = ['venv', '.venv', 'build']
+exclude = ['venv', '.venv', 'build', 'docs']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = ["black", "ruff", "mypy", "pre-commit", "pytest", "pytest-cov"]
+docs = ["sphinx", "m2r2"]
 
 [project.urls]
 "Homepage" = "https://github.com/nismod/DAFNI-NIRD"


### PR DESCRIPTION
This pull request adds the `docs` directory and sets up the process for building a documentation site.

Can you check the setup works for you locally @YueeeeeLi ?
- [x] Install the [Sphinx](https://www.sphinx-doc.org/en/master/) package `micromamba install -f environment.yaml`
- [x] Build the docs following the new notes in the README
